### PR TITLE
Build with Stackage LTS 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,32 @@
-language: haskell
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# GHC depends on GMP. You can add other dependencies here as well.
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+
+# The different configurations we want to test. You could also do things like
+# change flags or use --stack-yaml to point to a different file.
+env:
+- ARGS=""
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+# This line does all of the work: installs GHC if necessary, build the library,
+# executables, and test suites, and runs the test suites. --no-terminal works
+# around some quirks in Travis's terminal implementation.
+script: stack $ARGS --no-terminal --install-ghc test --haddock
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack

--- a/Hakyll/Convert/Blogger.hs
+++ b/Hakyll/Convert/Blogger.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE FlexibleContexts   #-}
 module Hakyll.Convert.Blogger
     (FullPost(..), readPosts, distill)
   where
@@ -20,8 +21,7 @@ import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as T
 import           Data.Time                    (UTCTime)
-import           Data.Time.Format             (parseTime, formatTime)
-import           System.Locale                (defaultTimeLocale)
+import           Data.Time.Format             (parseTimeM, formatTime, defaultTimeLocale)
 
 import           Hakyll.Core.Compiler
 import           Hakyll.Core.Item
@@ -185,7 +185,7 @@ distill fp = DistilledPost
         case parseTime' =<< entryPublished x of
             Nothing -> "1970-01-01"
             Just  d -> formatTime' d
-    parseTime' d = msum $ map (\f -> parseTime defaultTimeLocale f d)
+    parseTime' d = msum $ map (\f -> parseTimeM True defaultTimeLocale f d)
         [ "%FT%T%Q%z"  -- with time zone
         , "%FT%T%QZ"   -- zulu time
         ]

--- a/Hakyll/Convert/Wordpress.hs
+++ b/Hakyll/Convert/Wordpress.hs
@@ -10,8 +10,7 @@ import           Data.Maybe
 import qualified Data.Text              as T
 import qualified Data.Text.Encoding     as T
 import           Data.Time              (UTCTime)
-import           Data.Time.Format       (parseTime, formatTime)
-import           System.Locale          (defaultTimeLocale, rfc822DateFormat)
+import           Data.Time.Format       (parseTimeM, formatTime, defaultTimeLocale, rfc822DateFormat)
 import           Text.XML.Light
 import           Text.RSS.Import
 import           Text.RSS.Syntax
@@ -59,7 +58,7 @@ distill item = DistilledPost
     date = case parseTime' =<< rssItemPubDate item of
                Nothing -> "1970-01-01"
                Just d  -> T.pack (formatTime' d)
-    parseTime' d = msum $ map (\f -> parseTime defaultTimeLocale f d)
+    parseTime' d = msum $ map (\f -> parseTimeM True defaultTimeLocale f d)
         [ rfc822DateFormat
         ]
     formatTime' :: UTCTime -> String

--- a/hakyll-convert.cabal
+++ b/hakyll-convert.cabal
@@ -24,7 +24,6 @@ library
                ,       bytestring
                ,       feed
                ,       hakyll
-               ,       old-locale
                ,       text
                ,       time
                ,       xml

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,35 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-5.18
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
This fixes the type error by dropping old-locale altogether; adds `stack.yaml`; enables Stack builds on Travis.

Not much, but at least the next person will have much less trouble getting it to compile.